### PR TITLE
move expand.path() call down to c level

### DIFF
--- a/R/geojson.R
+++ b/R/geojson.R
@@ -77,8 +77,6 @@ read_geojson_str <- function(str, opts = list(), ...) {
 read_geojson_file <- function(filename, opts = list(), ...) {
   opts <- modify_list(opts, list(...))
 
-  filename <- path.expand(filename[1])
-
   .Call(
     parse_geojson_file_,
     filename, 

--- a/R/json.R
+++ b/R/json.R
@@ -69,9 +69,6 @@ read_json_raw <- function(raw_vec, opts = list(), ...) {
 #' @export
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 read_json_file <- function(filename, opts = list(), ...) {
-
-  filename <- path.expand(filename[1])
-
   .Call(
     parse_from_file_, 
     filename, 

--- a/R/ndjson.R
+++ b/R/ndjson.R
@@ -37,8 +37,6 @@ read_ndjson_file <- function(filename, type = c('df', 'list'), nread = -1, nskip
   
   type <- match.arg(type)
 
-  filename <- path.expand(filename[1])
-  
   if (type == 'list') {
     .Call(
       parse_ndjson_file_as_list_,

--- a/src/R-yyjson-parse.c
+++ b/src/R-yyjson-parse.c
@@ -1868,6 +1868,7 @@ SEXP parse_from_raw_(SEXP raw_, SEXP parse_opts_) {
 SEXP parse_from_file_(SEXP filename_, SEXP parse_opts_) {
   
   const char *filename = (const char *)CHAR( STRING_ELT(filename_, 0) );
+  filename = R_ExpandFileName(filename);
   parse_options opt = create_parse_options(parse_opts_);
   
   return parse_json_from_file(filename, &opt);

--- a/src/geojson.c
+++ b/src/geojson.c
@@ -1587,6 +1587,7 @@ SEXP parse_geojson_file_(SEXP filename_, SEXP geo_opts_, SEXP parse_opts_) {
   opt.parse_opt = &parse_opt;
   
   const char *filename = (const char *)CHAR( STRING_ELT(filename_, 0) );
+  filename = R_ExpandFileName(filename);
   yyjson_read_err err;
   yyjson_doc *doc = yyjson_read_file((char *)filename, opt.yyjson_read_flag, NULL, &err);
   

--- a/src/ndjson.c
+++ b/src/ndjson.c
@@ -114,7 +114,8 @@ SEXP parse_ndjson_file_as_list_(SEXP filename_, SEXP nread_, SEXP nskip_, SEXP p
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // Check for file
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  char *filename = (char *)CHAR(STRING_ELT(filename_, 0));
+  const char *filename = (const char *)CHAR(STRING_ELT(filename_, 0));
+  filename = R_ExpandFileName(filename);
   if (access(filename, R_OK) != 0) {
     error("Cannot read from file '%s'", filename);
   }
@@ -229,8 +230,8 @@ SEXP parse_ndjson_file_as_df_(SEXP filename_, SEXP nread_, SEXP nskip_, SEXP npr
   unsigned int nprotect = 0;
   char buf[MAX_LINE_LENGTH];
   parse_options opt = create_parse_options(parse_opts_);
-  char *filename = (char *)CHAR(STRING_ELT(filename_, 0));
-  
+  const char *filename = (const char *)CHAR(STRING_ELT(filename_, 0));
+  filename = R_ExpandFileName(filename);
   
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // Check for file


### PR DESCRIPTION
All credit to @hrbrmstr for the suggestion. I'm simply moving this call down in the interests of keeping `yysonr` as fast as possible.