### PR TITLE
add support for json_verbatim

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: yyjsonr
 Type: Package
 Title: Fast 'JSON', 'NDJSON' and 'GeoJSON' Parser and Generator 
-Version: 0.1.20.9001
+Version: 0.1.20.9101
 Authors@R: c(
     person("Mike", "Cheng", role = c("aut", "cre", 'cph'), 
     email = "mikefc@coolbutuseless.com"),

--- a/R/json-opts.R
+++ b/R/json-opts.R
@@ -290,6 +290,7 @@ opts_write_json <- function(
     num_specials      = c('null', 'string'),
     str_specials      = c('null', 'string'),
     fast_numerics     = FALSE,
+    json_verbatim     = FALSE,
     yyjson_write_flag = 0L) {
   
   structure(
@@ -303,6 +304,7 @@ opts_write_json <- function(
       str_specials      = match.arg(str_specials),
       num_specials      = match.arg(num_specials),
       fast_numerics     = isTRUE(fast_numerics),
+      json_verbatim     = isTRUE(json_verbatim),
       yyjson_write_flag = as.integer(yyjson_write_flag)
     ),
     class = "opts_write_json"

--- a/src/R-yyjson-serialize.h
+++ b/src/R-yyjson-serialize.h
@@ -76,6 +76,7 @@ typedef struct {
   unsigned int num_specials;
   unsigned int yyjson_write_flag;
   bool fast_numerics;
+  bool json_verbatim;
 } serialize_options;
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/testthat/test-json-verbatim.R
+++ b/tests/testthat/test-json-verbatim.R
@@ -1,0 +1,87 @@
+test_that("json_verbatim basic behavior", {
+    chr1 <- '[1,2,3]'
+    chr3 <- rep(chr1, 3)
+    json1 <- chr1; class(json1) <- "json"
+    json3 <- chr3; class(json3) <- "json"
+
+    expect_identical(
+        write_json_str(chr1, auto_unbox = FALSE, json_verbatim = FALSE),
+        '["[1,2,3]"]'
+    )
+    expect_identical(
+        write_json_str(chr1, auto_unbox = TRUE, json_verbatim = FALSE),
+        '"[1,2,3]"'
+    )
+    expect_identical(
+        write_json_str(chr1, auto_unbox = FALSE, json_verbatim = TRUE),
+        '["[1,2,3]"]'
+    )
+    expect_identical(
+        write_json_str(chr1, auto_unbox = TRUE, json_verbatim = TRUE),
+        '"[1,2,3]"'
+    )
+
+    expect_identical(
+        write_json_str(json1, auto_unbox = FALSE, json_verbatim = FALSE),
+        '["[1,2,3]"]'
+    )
+    expect_identical(
+        write_json_str(json1, auto_unbox = TRUE, json_verbatim = FALSE),
+        '"[1,2,3]"'
+    )
+    expect_identical(
+        write_json_str(json1, auto_unbox = FALSE, json_verbatim = TRUE),
+        '[[1,2,3]]'
+    )
+    expect_identical(
+        write_json_str(json1, auto_unbox = TRUE, json_verbatim = TRUE),
+        '[1,2,3]'
+    )
+
+    expect_identical(
+        write_json_str(chr3, auto_unbox = FALSE, json_verbatim = FALSE),
+        '["[1,2,3]","[1,2,3]","[1,2,3]"]'
+    )
+    expect_identical(
+        write_json_str(chr3, auto_unbox = TRUE, json_verbatim = FALSE),
+        '["[1,2,3]","[1,2,3]","[1,2,3]"]'
+    )
+    expect_identical(
+        write_json_str(chr3, auto_unbox = FALSE, json_verbatim = TRUE),
+        '["[1,2,3]","[1,2,3]","[1,2,3]"]'
+    )
+    expect_identical(
+        write_json_str(chr3, auto_unbox = TRUE, json_verbatim = TRUE),
+        '["[1,2,3]","[1,2,3]","[1,2,3]"]'
+    )
+
+    expect_identical(
+        write_json_str(json3, auto_unbox = FALSE, json_verbatim = FALSE),
+        '["[1,2,3]","[1,2,3]","[1,2,3]"]'
+    )
+    expect_identical(
+        write_json_str(json3, auto_unbox = TRUE, json_verbatim = FALSE),
+        '["[1,2,3]","[1,2,3]","[1,2,3]"]'
+    )
+    expect_identical(
+        write_json_str(json3, auto_unbox = FALSE, json_verbatim = TRUE),
+        '[[1,2,3],[1,2,3],[1,2,3]]'
+    )
+    expect_identical(
+        write_json_str(json3, auto_unbox = TRUE, json_verbatim = TRUE),
+        '[[1,2,3],[1,2,3],[1,2,3]]'
+    )    
+})
+
+test_that("json_verbatim failures", {
+    x <- list(
+        foo = "bar"
+    )
+    class(x$foo) <- "json"  ## this is a bad class assignment, since "bar" isn't quote-wrapped.
+
+    valid_json <- write_json_str(x, auto_unbox = TRUE, json_verbatim = FALSE)
+    invalid_json <- write_json_str(x, auto_unbox = TRUE, json_verbatim = TRUE)
+
+    expect_true(yyjsonr::validate_json_str(valid_json))
+    expect_false(yyjsonr::validate_json_str(invalid_json))
+})


### PR DESCRIPTION
This adds support for a `json_verbatim` boolean flag that functions similarly to {jsonlite}'s equivalent flag, addressing #25.

When an atomic character vector is passed to {yyjsonr}'s serializer, there's now a check to see if that vector (element) inherits from the "json" class. If the element does and the new `json_verbatim` flag is `TRUE`, then the raw string (`char*`) is inserted into the growing yyjson JSON doc _as-is_.

There is no check for JSON-validity of this string, so it's up to the user to know that such strings are indeed already valid JSON; this is the same here-be-dragons situation as with the `fast_numerics` flag.

In #25, the OP-proposed flag name was `skip_json`, but I thought it'd be useful to actually try to replicate {jsonlite}'s API in this instance and stick with `json_verbatim`, but obviously I defer to @coolbutuseless on naming preferences.

Tests are included to handle some basic cases, which can be used for documentation. If it looks like this'll indeed be merged, I can add another commit adding those docs, but figured I'd wait on those until it looks like this will be merged (since perhaps there'll be some discussion and changes along the way).

