### PR TITLE
Updates to handle Dataset JSON use case for NDJSON format

### DIFF
--- a/R/json-opts.R
+++ b/R/json-opts.R
@@ -285,10 +285,14 @@ opts_read_json <- function(
 #'        \code{YYJSON_WRITE_INF_AND_NAN_AS_NULL} options for \code{yyjson_write_flags}
 #'        and should consult the \code{yyjson} API documentation for 
 #'        further details.
-#' @param json_verbatim Write strings with class 'json' directly into 
+#' @param json_verbatim Write strings with class 'json' directly into
 #'        the result?  Default: FALSE.  If \code{json_verbatim = TRUE} and
 #'        a string has the class \code{"json"}, then it will be written verbatim
 #'        into the output.
+#' @param asis How to handle \code{I()} (AsIs class) when \code{auto_unbox = TRUE}.
+#'        Default: \code{"keep"} preserves the existing behaviour where \code{I(x)}
+#'        forces array output even with auto_unbox. \code{"strip"} ignores the AsIs
+#'        class and unboxes length-1 vectors normally.
 #' @param yyjson_write_flag integer vector corresponding to internal \code{yyjson}
 #'        options.  See \code{yyjson_write_flag} in this package, and read
 #'        the yyjson API documentation for more information.  This is considered
@@ -314,8 +318,9 @@ opts_write_json <- function(
     str_specials      = c('null', 'string'),
     fast_numerics     = FALSE,
     json_verbatim     = FALSE,
+    asis              = c("keep", "strip"),
     yyjson_write_flag = 0L) {
-  
+
   structure(
     list(
       digits            = as.integer(digits),
@@ -330,6 +335,7 @@ opts_write_json <- function(
       num_specials      = match.arg(num_specials),
       fast_numerics     = isTRUE(fast_numerics),
       json_verbatim     = isTRUE(json_verbatim),
+      asis              = match.arg(asis),
       yyjson_write_flag = as.integer(yyjson_write_flag)
     ),
     class = "opts_write_json"

--- a/R/ndjson.R
+++ b/R/ndjson.R
@@ -25,27 +25,31 @@
 #'        (skip no data)
 #' @param nprobe Number of lines to read to determine types for data.frame
 #'        columns.  Default: 100.   Use \code{-1} to probe entire file.
+#' @param col_names Character vector of column names.  Used when NDJSON lines
+#'        are JSON arrays (values only, no keys).  If \code{NULL} (default),
+#'        column names are inferred from JSON object keys, or generated as
+#'        "V1", "V2", ... for array-format lines.
 #'
 #'
 #' @examples
 #' tmp <- tempfile()
 #' write_ndjson_file(head(mtcars), tmp)
 #' read_ndjson_file(tmp)
-#' 
+#'
 #' @family JSON Parsers
-#' @return NDJSON data read into R as list or data.frame depending 
+#' @return NDJSON data read into R as list or data.frame depending
 #'         on \code{'type'} argument
 #' @export
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-read_ndjson_file <- function(filename, type = c('df', 'list'), nread = -1, nskip = 0, nprobe = 100, opts = list(), ...) {
-  
+read_ndjson_file <- function(filename, type = c('df', 'list'), nread = -1, nskip = 0, nprobe = 100, col_names = NULL, opts = list(), ...) {
+
   type <- match.arg(type)
   filename <- normalizePath(filename, mustWork = TRUE)
-  
+
   if (type == 'list') {
     .Call(
       parse_ndjson_file_as_list_,
-      filename, 
+      filename,
       nread,
       nskip,
       modify_list(opts, list(...))
@@ -53,10 +57,11 @@ read_ndjson_file <- function(filename, type = c('df', 'list'), nread = -1, nskip
   } else {
     .Call(
       parse_ndjson_file_as_df_,
-      filename, 
+      filename,
       nread,
       nskip,
       nprobe,
+      col_names,
       modify_list(opts, list(...))
     )
   }
@@ -91,14 +96,14 @@ read_ndjson_file <- function(filename, type = c('df', 'list'), nread = -1, nskip
 #'         on \code{'type'} argument
 #' @export
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-read_ndjson_str <- function(x, type = c('df', 'list'), nread = -1, nskip = 0, nprobe = 100, opts = list(), ...) {
-  
+read_ndjson_str <- function(x, type = c('df', 'list'), nread = -1, nskip = 0, nprobe = 100, col_names = NULL, opts = list(), ...) {
+
   type <- match.arg(type)
-  
+
   if (type == 'list') {
     .Call(
       parse_ndjson_str_as_list_,
-      x, 
+      x,
       nread,
       nskip,
       modify_list(opts, list(...))
@@ -106,10 +111,11 @@ read_ndjson_str <- function(x, type = c('df', 'list'), nread = -1, nskip = 0, np
   } else {
     .Call(
       parse_ndjson_str_as_df_,
-      x, 
+      x,
       nread,
       nskip,
       nprobe,
+      col_names,
       modify_list(opts, list(...))
     )
   }
@@ -145,14 +151,14 @@ read_ndjson_str <- function(x, type = c('df', 'list'), nread = -1, nskip = 0, np
 #'         on \code{'type'} argument
 #' @export
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-read_ndjson_raw <- function(x, type = c('df', 'list'), nread = -1, nskip = 0, nprobe = 100, opts = list(), ...) {
-  
+read_ndjson_raw <- function(x, type = c('df', 'list'), nread = -1, nskip = 0, nprobe = 100, col_names = NULL, opts = list(), ...) {
+
   type <- match.arg(type)
-  
+
   if (type == 'list') {
     .Call(
       parse_ndjson_str_as_list_,
-      x, 
+      x,
       nread,
       nskip,
       modify_list(opts, list(...))
@@ -160,10 +166,11 @@ read_ndjson_raw <- function(x, type = c('df', 'list'), nread = -1, nskip = 0, np
   } else {
     .Call(
       parse_ndjson_str_as_df_,
-      x, 
+      x,
       nread,
       nskip,
       nprobe,
+      col_names,
       modify_list(opts, list(...))
     )
   }

--- a/man/opts_write_json.Rd
+++ b/man/opts_write_json.Rd
@@ -17,6 +17,7 @@ opts_write_json(
   str_specials = c("null", "string"),
   fast_numerics = FALSE,
   json_verbatim = FALSE,
+  asis = c("keep", "strip"),
   yyjson_write_flag = 0L
 )
 }
@@ -75,6 +76,11 @@ further details.}
 the result?  Default: FALSE.  If \code{json_verbatim = TRUE} and
 a string has the class \code{"json"}, then it will be written verbatim
 into the output.}
+
+\item{asis}{How to handle \code{I()} (AsIs class) when \code{auto_unbox = TRUE}.
+Default: \code{"keep"} preserves the existing behaviour where \code{I(x)}
+forces array output even with auto_unbox. \code{"strip"} ignores the AsIs
+class and unboxes length-1 vectors normally.}
 
 \item{yyjson_write_flag}{integer vector corresponding to internal \code{yyjson}
 options.  See \code{yyjson_write_flag} in this package, and read

--- a/man/read_ndjson_file.Rd
+++ b/man/read_ndjson_file.Rd
@@ -10,6 +10,7 @@ read_ndjson_file(
   nread = -1,
   nskip = 0,
   nprobe = 100,
+  col_names = NULL,
   opts = list(),
   ...
 )
@@ -28,6 +29,11 @@ values are 'df' or 'list'.  Default: 'df' (data.frame)}
 
 \item{nprobe}{Number of lines to read to determine types for data.frame
 columns.  Default: 100.   Use \code{-1} to probe entire file.}
+
+\item{col_names}{Character vector of column names.  Used when NDJSON lines
+are JSON arrays (values only, no keys).  If \code{NULL} (default),
+column names are inferred from JSON object keys, or generated as
+"V1", "V2", ... for array-format lines.}
 
 \item{opts}{Named list of options for parsing. Usually created by \code{opts_read_json()}}
 

--- a/man/read_ndjson_raw.Rd
+++ b/man/read_ndjson_raw.Rd
@@ -10,6 +10,7 @@ read_ndjson_raw(
   nread = -1,
   nskip = 0,
   nprobe = 100,
+  col_names = NULL,
   opts = list(),
   ...
 )
@@ -27,6 +28,11 @@ values are 'df' or 'list'.  Default: 'df' (data.frame)}
 
 \item{nprobe}{Number of lines to read to determine types for data.frame
 columns.  Default: 100.   Use \code{-1} to probe entire file.}
+
+\item{col_names}{Character vector of column names.  Used when NDJSON lines
+are JSON arrays (values only, no keys).  If \code{NULL} (default),
+column names are inferred from JSON object keys, or generated as
+"V1", "V2", ... for array-format lines.}
 
 \item{opts}{Named list of options for parsing. Usually created by \code{opts_read_json()}}
 

--- a/man/read_ndjson_str.Rd
+++ b/man/read_ndjson_str.Rd
@@ -10,6 +10,7 @@ read_ndjson_str(
   nread = -1,
   nskip = 0,
   nprobe = 100,
+  col_names = NULL,
   opts = list(),
   ...
 )
@@ -27,6 +28,11 @@ values are 'df' or 'list'.  Default: 'df' (data.frame)}
 
 \item{nprobe}{Number of lines to read to determine types for data.frame
 columns.  Default: 100.   Use \code{-1} to probe entire file.}
+
+\item{col_names}{Character vector of column names.  Used when NDJSON lines
+are JSON arrays (values only, no keys).  If \code{NULL} (default),
+column names are inferred from JSON object keys, or generated as
+"V1", "V2", ... for array-format lines.}
 
 \item{opts}{Named list of options for parsing. Usually created by \code{opts_read_json()}}
 

--- a/src/R-yyjson-serialize.c
+++ b/src/R-yyjson-serialize.c
@@ -41,6 +41,7 @@ serialize_options parse_serialize_options(SEXP serialize_opts_) {
     .str_specials      = STR_SPECIALS_AS_NULL,
     .fast_numerics     = FALSE,
     .yyjson_write_flag = 0,
+    .asis              = ASIS_KEEP,
   };
   
   // Sanity check and get option names
@@ -100,6 +101,9 @@ serialize_options parse_serialize_options(SEXP serialize_opts_) {
       opt.json_verbatim = Rf_asLogical(val_);
     } else if (strcmp(opt_name, "fast_numerics") == 0) {
       opt.fast_numerics = Rf_asLogical(val_);
+    } else if (strcmp(opt_name, "asis") == 0) {
+      const char *tmp = CHAR(STRING_ELT(val_, 0));
+      opt.asis = strcmp(tmp, "keep") == 0 ? ASIS_KEEP : ASIS_STRIP;
     } else {
       Rf_warning("Unknown option ignored: '%s'\n", opt_name);
     }
@@ -1184,7 +1188,7 @@ yyjson_mut_val *serialize_core(SEXP robj_, yyjson_mut_doc *doc, serialize_option
     val = dim3_matrix_to_col_major_array(robj_, doc, opt);
   } else if (Rf_isVectorAtomic(robj_) && Rf_length(robj_) == 1 && 
     (opt->auto_unbox || Rf_inherits(robj_, "scalar"))) {
-    if (Rf_inherits(robj_, "AsIs")) {
+    if (opt->asis == ASIS_KEEP && Rf_inherits(robj_, "AsIs")) {
       val = vector_to_json_array(robj_, doc, opt);
     } else {
       switch(TYPEOF(robj_)) {

--- a/src/R-yyjson-serialize.h
+++ b/src/R-yyjson-serialize.h
@@ -17,6 +17,9 @@
 #define NAME_REPAIR_NONE    0
 #define NAME_REPAIR_MINIMAL 1
 
+#define ASIS_KEEP  0
+#define ASIS_STRIP 1
+
 
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -79,6 +82,7 @@ typedef struct {
   unsigned int yyjson_write_flag;
   bool fast_numerics;
   bool json_verbatim;
+  unsigned int asis;
 } serialize_options;
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -97,4 +101,5 @@ yyjson_mut_val *scalar_double_to_json_val(double rdbl, yyjson_mut_doc *doc, seri
 yyjson_mut_val *scalar_strsxp_to_json_val(SEXP str_, R_xlen_t idx, yyjson_mut_doc *doc, serialize_options *opt);
 
 yyjson_mut_val *data_frame_row_to_json_object(SEXP df_, unsigned int *col_type, unsigned int row, int skip_col, yyjson_mut_doc *doc, serialize_options *opt);
+yyjson_mut_val *data_frame_row_to_json_array(SEXP df_, unsigned int *col_type, unsigned int row, int skip_col, yyjson_mut_doc *doc, serialize_options *opt);
 unsigned int *detect_data_frame_types(SEXP df_, serialize_options *opt);

--- a/src/init.c
+++ b/src/init.c
@@ -23,10 +23,10 @@ extern SEXP validate_json_str_ (SEXP str_     , SEXP verbose_, SEXP parse_opts_)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // NDJSON
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-extern SEXP parse_ndjson_file_as_df_  (SEXP filename_, SEXP nread_, SEXP nskip_, SEXP nprobe_, SEXP parse_opts_);
+extern SEXP parse_ndjson_file_as_df_  (SEXP filename_, SEXP nread_, SEXP nskip_, SEXP nprobe_, SEXP col_names_, SEXP parse_opts_);
 extern SEXP parse_ndjson_file_as_list_(SEXP filename_, SEXP nread_, SEXP nskip_,               SEXP parse_opts_);
 
-extern SEXP parse_ndjson_str_as_df_  (SEXP str_, SEXP nread_, SEXP nskip_, SEXP nprobe_, SEXP parse_opts_);
+extern SEXP parse_ndjson_str_as_df_  (SEXP str_, SEXP nread_, SEXP nskip_, SEXP nprobe_, SEXP col_names_, SEXP parse_opts_);
 extern SEXP parse_ndjson_str_as_list_(SEXP str_, SEXP nread_, SEXP nskip_,               SEXP parse_opts_);
 
 extern SEXP serialize_df_to_ndjson_str_ (SEXP robj_,                 SEXP serialize_opts_, SEXP as_raw_);
@@ -65,10 +65,10 @@ static const R_CallMethodDef CEntries[] = {
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // NDJSON
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  {"parse_ndjson_file_as_df_"  , (DL_FUNC) &parse_ndjson_file_as_df_  , 5},
+  {"parse_ndjson_file_as_df_"  , (DL_FUNC) &parse_ndjson_file_as_df_  , 6},
   {"parse_ndjson_file_as_list_", (DL_FUNC) &parse_ndjson_file_as_list_, 4},
-  
-  {"parse_ndjson_str_as_df_"  , (DL_FUNC) &parse_ndjson_str_as_df_  , 5},
+
+  {"parse_ndjson_str_as_df_"  , (DL_FUNC) &parse_ndjson_str_as_df_  , 6},
   {"parse_ndjson_str_as_list_", (DL_FUNC) &parse_ndjson_str_as_list_, 4},
   
   {"serialize_df_to_ndjson_str_" , (DL_FUNC) &serialize_df_to_ndjson_str_ , 3},

--- a/src/ndjson-parse.c
+++ b/src/ndjson-parse.c
@@ -428,34 +428,34 @@ SEXP promote_list_to_data_frame(SEXP df_, char **colname, int ncols) {
 //        it.  No re-allocation as we pre-determine the number of rows and 
 //        type for each columnx
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-SEXP parse_ndjson_file_as_df_(SEXP filename_, SEXP nread_, SEXP nskip_, SEXP nprobe_, SEXP parse_opts_) {
-  
+SEXP parse_ndjson_file_as_df_(SEXP filename_, SEXP nread_, SEXP nskip_, SEXP nprobe_, SEXP col_names_, SEXP parse_opts_) {
+
   int nprotect = 0;
   char buf[MAX_LINE_LENGTH] = {0};
   parse_options opt = create_parse_options(parse_opts_);
   const char *filename = (const char *)CHAR(STRING_ELT(filename_, 0));
   filename = R_ExpandFileName(filename);
-  
+
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // Check for file
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   if (access(filename, R_OK) != 0) {
     Rf_error("Cannot read from file '%s'", filename);
   }
-  
-  
+
+
   int nread  = Rf_asInteger(nread_);
   int nskip  = Rf_asInteger(nskip_);
   int nprobe = Rf_asInteger(nprobe_);
-  
+
   if (nread < 0) {
     nread = INT32_MAX;
   }
-  
+
   if (nprobe < 0) {
     nprobe = INT32_MAX;
   }
-  
+
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // Get the maximum possible number of json rows in this ndjson file.
   // Note: the actual number of rows to parse may be less than this due
@@ -463,13 +463,13 @@ SEXP parse_ndjson_file_as_df_(SEXP filename_, SEXP nread_, SEXP nskip_, SEXP npr
   // 'nrows' controls the amount of memory pre-allocated for rows in the df.
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   int nrows = count_lines(filename);
-  
+
   // Account for rows to be skipped
   nrows = nrows - nskip;
   if (nrows < 0) {
     nrows = 0;
   }
-  
+
   // Ensure we don't read more than the user requested
   if (nrows > nread) {
     nrows = nread;
@@ -483,13 +483,13 @@ SEXP parse_ndjson_file_as_df_(SEXP filename_, SEXP nread_, SEXP nskip_, SEXP npr
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   unsigned int type_bitset[MAX_DF_COLS] = {0};
   unsigned int sexp_type[MAX_DF_COLS] = {0};
-  
-  
+
+
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // Probe file for types
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   gzFile input = gzopen(filename, "r");
-  
+
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // Skip lines if requested
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -500,75 +500,140 @@ SEXP parse_ndjson_file_as_df_(SEXP filename_, SEXP nread_, SEXP nskip_, SEXP npr
       if (nskip2 == 0) break;
     }
   }
-  
-  
+
+
   state_t *state = create_state();
-  
+  int array_mode = -1; // -1 = unknown, 0 = object, 1 = array
+
   for (unsigned int i = 0; i < nprobe; i++) {
     char *ret = gzgets(input, buf, MAX_LINE_LENGTH);
     if (ret == NULL) {
       break;
     }
-    
-    
+
+
     // ignore lines which are just a "\n".
     // might have to do something fancier for lines with just whitespace
     if (strlen(buf) <= 1) continue;
-    
+
     yyjson_read_err err;
     state->doc = yyjson_read_opts(buf, strlen(buf), opt.yyjson_read_flag, NULL, &err);
     if (state->doc == NULL) {
       output_verbose_error(buf, strlen(buf), err);
       error_and_destroy_state(state, "Couldn't parse JSON during probe line %i\n", i + 1);
     }
-    
+
     yyjson_val *obj = yyjson_doc_get_root(state->doc);
-    yyjson_val *key;
-    yyjson_obj_iter obj_iter = yyjson_obj_iter_with(obj); // MUST be an object
-    
-    while ((key = yyjson_obj_iter_next(&obj_iter))) {
-      yyjson_val *val = yyjson_obj_iter_get_val(key);
-      
-      int name_idx = -1;
-      for (int i = 0; i < state->ncols; i++) {
-        if (yyjson_equals_str(key, state->colnames[i])) {
-          name_idx = i;
-          break;
-        }
+    uint8_t root_type = yyjson_get_type(obj);
+
+    // Auto-detect mode from first parsed line
+    if (array_mode == -1) {
+      if (root_type == YYJSON_TYPE_OBJ) {
+        array_mode = 0;
+      } else if (root_type == YYJSON_TYPE_ARR) {
+        array_mode = 1;
+      } else {
+        error_and_destroy_state(state, "parse_ndjson_as_df() requires JSON objects or arrays on each line");
       }
-      if (name_idx < 0) {
-        // Name has not been seen yet.
-        // Need to copy the string as the 'doc' it is from is freed at the end of every loop
-        name_idx = state->ncols;
-        char *new_name = (char *)yyjson_get_str(key);
-        size_t n = strlen(new_name) + 1;
-        state->colnames[state->ncols] = calloc(n, 1);
-        if (state->colnames[state->ncols] == 0) {
-          error_and_destroy_state(state, "Failed to allocate 'colname'");
-        }
-        strcpy(state->colnames[state->ncols], new_name);
-        state->ncols++;
-        if (state->ncols == MAX_DF_COLS) {
+    }
+
+    if (array_mode == 1) {
+      // Array mode: track types by position
+      size_t arr_size = yyjson_arr_size(obj);
+      if ((int)arr_size > state->ncols) {
+        state->ncols = (int)arr_size;
+        if (state->ncols >= MAX_DF_COLS) {
           error_and_destroy_state(state, "Maximum columns for data.frame exceeded: %i", MAX_DF_COLS);
         }
       }
-      
-      type_bitset[name_idx] = update_type_bitset(type_bitset[name_idx], val, &opt);
+      yyjson_arr_iter arr_iter = yyjson_arr_iter_with(obj);
+      yyjson_val *val;
+      int pos = 0;
+      while ((val = yyjson_arr_iter_next(&arr_iter))) {
+        type_bitset[pos] = update_type_bitset(type_bitset[pos], val, &opt);
+        pos++;
+      }
+    } else {
+      // Object mode: existing key-based probing
+      yyjson_val *key;
+      yyjson_obj_iter obj_iter = yyjson_obj_iter_with(obj);
+
+      while ((key = yyjson_obj_iter_next(&obj_iter))) {
+        yyjson_val *val = yyjson_obj_iter_get_val(key);
+
+        int name_idx = -1;
+        for (int j = 0; j < state->ncols; j++) {
+          if (yyjson_equals_str(key, state->colnames[j])) {
+            name_idx = j;
+            break;
+          }
+        }
+        if (name_idx < 0) {
+          // Name has not been seen yet.
+          // Need to copy the string as the 'doc' it is from is freed at the end of every loop
+          name_idx = state->ncols;
+          char *new_name = (char *)yyjson_get_str(key);
+          size_t n = strlen(new_name) + 1;
+          state->colnames[state->ncols] = calloc(n, 1);
+          if (state->colnames[state->ncols] == 0) {
+            error_and_destroy_state(state, "Failed to allocate 'colname'");
+          }
+          strcpy(state->colnames[state->ncols], new_name);
+          state->ncols++;
+          if (state->ncols == MAX_DF_COLS) {
+            error_and_destroy_state(state, "Maximum columns for data.frame exceeded: %i", MAX_DF_COLS);
+          }
+        }
+
+        type_bitset[name_idx] = update_type_bitset(type_bitset[name_idx], val, &opt);
+      }
     }
-    
+
     yyjson_doc_free(state->doc);
     state->doc = NULL;
   }
-  
+
   gzclose(input);
-  
+
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // Set column names for array mode
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  if (array_mode == 1) {
+    if (!Rf_isNull(col_names_) && TYPEOF(col_names_) == STRSXP) {
+      int user_ncols = Rf_length(col_names_);
+      if (user_ncols != state->ncols) {
+        error_and_destroy_state(state, "col_names length (%d) does not match array size (%d)", user_ncols, state->ncols);
+      }
+      for (int i = 0; i < state->ncols; i++) {
+        const char *nm = CHAR(STRING_ELT(col_names_, i));
+        size_t n = strlen(nm) + 1;
+        state->colnames[i] = calloc(n, 1);
+        if (state->colnames[i] == NULL) {
+          error_and_destroy_state(state, "Failed to allocate colname");
+        }
+        strcpy(state->colnames[i], nm);
+      }
+    } else {
+      for (int i = 0; i < state->ncols; i++) {
+        char nbuf[32];
+        snprintf(nbuf, sizeof(nbuf), "V%d", i + 1);
+        size_t n = strlen(nbuf) + 1;
+        state->colnames[i] = calloc(n, 1);
+        if (state->colnames[i] == NULL) {
+          error_and_destroy_state(state, "Failed to allocate colname");
+        }
+        strcpy(state->colnames[i], nbuf);
+      }
+    }
+  }
+
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // Create a list (which will be promoted to a data.frame before returning)
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   SEXP df_ = PROTECT(Rf_allocVector(VECSXP, state->ncols)); nprotect++;
-  
-  
-  
+
+
+
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // For each column name,
   //   - determine the best SEXP to represent the 'type_bitset'
@@ -580,27 +645,27 @@ SEXP parse_ndjson_file_as_df_(SEXP filename_, SEXP nread_, SEXP nskip_, SEXP npr
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   for (unsigned int col = 0; col < state->ncols; col++) {
     sexp_type[col] = get_best_sexp_to_represent_type_bitset(type_bitset[col], &opt);
-    
+
     // INT64SXP is actually contained in a REALSXP
     unsigned int alloc_type = sexp_type[col] == INT64SXP ? REALSXP : sexp_type[col];
-    
+
     // Allocate memory for column
     SEXP vec_ = PROTECT(Rf_allocVector(alloc_type, nrows));
     if (sexp_type[col] == INT64SXP) {
       Rf_setAttrib(vec_, R_ClassSymbol, Rf_mkString("integer64"));
     }
-    
+
     // place vector into data.frame
     SET_VECTOR_ELT(df_, col, vec_);
     UNPROTECT(1); // no longer needs protection once part of data.frame
   }
-  
-  
+
+
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // Parse file
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   input = gzopen(filename, "r");
-  
+
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // Skip lines if requested
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -610,86 +675,139 @@ SEXP parse_ndjson_file_as_df_(SEXP filename_, SEXP nread_, SEXP nskip_, SEXP npr
       if (nskip == 0) break;
     }
   }
-  
+
   // keep track of actual number of rows parsed.
-  // This might not be the same as 'nrow' as we can skip rows that we 
+  // This might not be the same as 'nrow' as we can skip rows that we
   // can't parse.
   int row = 0;
-  
+
   for (unsigned int i = 0; i < nrows; i++) {
     char *ret = gzgets(input, buf, MAX_LINE_LENGTH);
     if (ret == NULL) {
       Rf_error("Unexepcted end to data\n");
     }
-    
+
     // ignore lines which are just a "\n".
     // might have to do something fancier for lines with just whitespace
     if (strlen(buf) <= 1) continue;
-    
+
     yyjson_read_err err;
     state->doc = yyjson_read_opts(buf, strlen(buf), opt.yyjson_read_flag, NULL, &err);
     if (state->doc == NULL) {
       output_verbose_error(buf, strlen(buf), err);
       error_and_destroy_state(state, "Couldn't parse JSON on line %i\n", i + 1);
     }
-    
+
     yyjson_val *obj = yyjson_doc_get_root(state->doc);
-    if (yyjson_get_type(obj) != YYJSON_TYPE_OBJ) {
-      error_and_destroy_state(state, "parse_ndjson_as_df() only works if all lines represent JSON objects");
-    }
-    
-    for (unsigned int col = 0; col < state->ncols; col++) {
-      SEXP column_ = VECTOR_ELT(df_, col);
-      
-      yyjson_val *val = yyjson_obj_get(obj, state->colnames[col]);
-      
-      switch(sexp_type[col]) {
-      case LGLSXP:
-        LOGICAL(column_)[row] = json_val_to_logical(val, &opt);
-        break;
-      case INTSXP:
-        INTEGER(column_)[row] = json_val_to_integer(val, &opt);
-        break;
-      case INT64SXP: {
-        long long tmp = json_val_to_integer64(val, &opt);
-        ((long long *)(REAL(column_)))[row] = tmp;
+
+    if (array_mode == 1) {
+      // Array mode: extract values by position
+      if (yyjson_get_type(obj) != YYJSON_TYPE_ARR) {
+        error_and_destroy_state(state, "Expected JSON array on line %i", i + 1);
       }
-        break;
-      case REALSXP:
-        REAL(column_)[row] = json_val_to_double(val, &opt);
-        break;
-      case STRSXP:
-        if (val == NULL) {
-          SET_STRING_ELT(column_, row, NA_STRING);
-        } else {
+      yyjson_arr_iter arr_iter = yyjson_arr_iter_with(obj);
+      yyjson_val *val;
+      unsigned int col = 0;
+      while ((val = yyjson_arr_iter_next(&arr_iter)) && col < state->ncols) {
+        SEXP column_ = VECTOR_ELT(df_, col);
+        switch(sexp_type[col]) {
+        case LGLSXP:
+          LOGICAL(column_)[row] = json_val_to_logical(val, &opt);
+          break;
+        case INTSXP:
+          INTEGER(column_)[row] = json_val_to_integer(val, &opt);
+          break;
+        case INT64SXP: {
+          long long tmp = json_val_to_integer64(val, &opt);
+          ((long long *)(REAL(column_)))[row] = tmp;
+        }
+          break;
+        case REALSXP:
+          REAL(column_)[row] = json_val_to_double(val, &opt);
+          break;
+        case STRSXP:
           SET_STRING_ELT(column_, row, json_val_to_charsxp(val, &opt));
-        }
-        break;
-      case VECSXP:
-        if (val == NULL) {
-          SET_VECTOR_ELT(column_, row, opt.df_missing_list_elem);
-        } else {
+          break;
+        case VECSXP:
           SET_VECTOR_ELT(column_, row, json_as_robj(val, &opt, state));
+          break;
+        default:
+          error_and_destroy_state(state, "parse_ndjson_file_as_df_(): Unknown type");
         }
-        break;
-      default:
-        error_and_destroy_state(state, "parse_ndjson_file_as_df_(): Unknown type");
-      } 
-      
+        col++;
+      }
+      // Fill remaining columns with NA if this row had fewer elements
+      for (; col < state->ncols; col++) {
+        SEXP column_ = VECTOR_ELT(df_, col);
+        switch(sexp_type[col]) {
+        case LGLSXP:  LOGICAL(column_)[row] = NA_LOGICAL; break;
+        case INTSXP:  INTEGER(column_)[row] = NA_INTEGER; break;
+        case INT64SXP: ((long long *)(REAL(column_)))[row] = INT64_MIN; break;
+        case REALSXP: REAL(column_)[row] = NA_REAL; break;
+        case STRSXP:  SET_STRING_ELT(column_, row, NA_STRING); break;
+        case VECSXP:  SET_VECTOR_ELT(column_, row, opt.df_missing_list_elem); break;
+        default: break;
+        }
+      }
+    } else {
+      // Object mode: extract values by key name
+      if (yyjson_get_type(obj) != YYJSON_TYPE_OBJ) {
+        error_and_destroy_state(state, "parse_ndjson_as_df() only works if all lines represent JSON objects");
+      }
+
+      for (unsigned int col = 0; col < state->ncols; col++) {
+        SEXP column_ = VECTOR_ELT(df_, col);
+
+        yyjson_val *val = yyjson_obj_get(obj, state->colnames[col]);
+
+        switch(sexp_type[col]) {
+        case LGLSXP:
+          LOGICAL(column_)[row] = json_val_to_logical(val, &opt);
+          break;
+        case INTSXP:
+          INTEGER(column_)[row] = json_val_to_integer(val, &opt);
+          break;
+        case INT64SXP: {
+          long long tmp = json_val_to_integer64(val, &opt);
+          ((long long *)(REAL(column_)))[row] = tmp;
+        }
+          break;
+        case REALSXP:
+          REAL(column_)[row] = json_val_to_double(val, &opt);
+          break;
+        case STRSXP:
+          if (val == NULL) {
+            SET_STRING_ELT(column_, row, NA_STRING);
+          } else {
+            SET_STRING_ELT(column_, row, json_val_to_charsxp(val, &opt));
+          }
+          break;
+        case VECSXP:
+          if (val == NULL) {
+            SET_VECTOR_ELT(column_, row, opt.df_missing_list_elem);
+          } else {
+            SET_VECTOR_ELT(column_, row, json_as_robj(val, &opt, state));
+          }
+          break;
+        default:
+          error_and_destroy_state(state, "parse_ndjson_file_as_df_(): Unknown type");
+        }
+
+      }
     }
-    
+
     yyjson_doc_free(state->doc);
     state->doc = NULL;
-    
+
     row++;
   }
-  
+
   gzclose(input);
-  
-  
+
+
   truncate_list_of_vectors(df_, row, nrows);
   SEXP df_final_ = PROTECT(promote_list_to_data_frame(df_, state->colnames, state->ncols)); nprotect++;
-  
+
   destroy_state(state);
   UNPROTECT(nprotect);
   return df_final_;
@@ -700,19 +818,19 @@ SEXP parse_ndjson_file_as_df_(SEXP filename_, SEXP nread_, SEXP nskip_, SEXP npr
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Parse string into data.frame
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-SEXP parse_ndjson_str_as_df_(SEXP str_, SEXP nread_, SEXP nskip_, SEXP nprobe_, SEXP parse_opts_) {
-  
+SEXP parse_ndjson_str_as_df_(SEXP str_, SEXP nread_, SEXP nskip_, SEXP nprobe_, SEXP col_names_, SEXP parse_opts_) {
+
   int nprotect = 0;
   parse_options opt = create_parse_options(parse_opts_);
   opt.yyjson_read_flag |= YYJSON_READ_STOP_WHEN_DONE;
-  
+
   int nread  = Rf_asInteger(nread_);
   int nskip  = Rf_asInteger(nskip_);
   int nprobe = Rf_asInteger(nprobe_);
-  
+
   if (nread  <= 0) { nread  = INT32_MAX; }
   if (nprobe <= 0) { nprobe = INT32_MAX; }
-  
+
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // Iterate over the file.  For each line
   //   - check if new data would overflow list
@@ -720,15 +838,15 @@ SEXP parse_ndjson_str_as_df_(SEXP str_, SEXP nread_, SEXP nskip_, SEXP nprobe_, 
   //   - create a yyjson doc from this line
   //   - if document is NULL
   //        insert a NULL into list
-  //   - otherwise 
+  //   - otherwise
   //        insert resulting robject into list
   //   - free the doc
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   char *str;
-  size_t str_size;      
-  size_t orig_str_size; 
-  size_t total_read = 0;    
-  
+  size_t str_size;
+  size_t orig_str_size;
+  size_t total_read = 0;
+
   if (TYPEOF(str_) == RAWSXP) {
     str           = (char *)RAW(str_);
     str_size      = (size_t)Rf_length(str_);
@@ -738,16 +856,16 @@ SEXP parse_ndjson_str_as_df_(SEXP str_, SEXP nread_, SEXP nskip_, SEXP nprobe_, 
     str_size      = strlen(str);
     orig_str_size = strlen(str);
   }
-  
+
   if (str_size == 0) {
     SEXP ll_ = PROTECT(Rf_allocVector(VECSXP, 0)); nprotect++;
     SEXP df_ = PROTECT(promote_list_to_data_frame(ll_, NULL, 0)); nprotect++;
     UNPROTECT(nprotect);
     return(df_);
   }
-  
-  
-  
+
+
+
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // Skip lines if requested
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -757,18 +875,18 @@ SEXP parse_ndjson_str_as_df_(SEXP str_, SEXP nread_, SEXP nskip_, SEXP nprobe_, 
     state->doc = yyjson_read_opts(str, str_size, opt.yyjson_read_flag, NULL, &err);
     size_t pos = yyjson_doc_get_read_size(state->doc);
     destroy_state(state);
-    
+
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // Advance string 
+    // Advance string
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     total_read += pos + 1;
     str += pos + 1;
     str_size -= (pos + 1);
-    
+
     nskip--;
   }
-  
-  
+
+
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // Accumulation of unique key-names in the objects
   // These will become the column names of the data.frame.
@@ -778,14 +896,15 @@ SEXP parse_ndjson_str_as_df_(SEXP str_, SEXP nread_, SEXP nskip_, SEXP nprobe_, 
   unsigned int type_bitset[MAX_DF_COLS] = {0};
   unsigned int sexp_type[MAX_DF_COLS] = {0};
   int nrows = 0;
-  
-  
+
+
   char *mark_str = str;
   size_t mark_str_size = str_size;
   size_t mark_total_read = total_read;
-  
+
   state_t *state = create_state();
-  
+  int array_mode = -1; // -1 = unknown, 0 = object, 1 = array
+
   while (nprobe > 0 && total_read < orig_str_size) {
     yyjson_read_err err;
     state->doc = yyjson_read_opts(str, str_size, opt.yyjson_read_flag, NULL, &err);
@@ -793,63 +912,89 @@ SEXP parse_ndjson_str_as_df_(SEXP str_, SEXP nread_, SEXP nskip_, SEXP nprobe_, 
     if (state->doc == NULL) {
       error_and_destroy_state(state, "Couldn't parse JSON during probe line %i\n", nrows + 1);
     }
-    
+
     yyjson_val *obj = yyjson_doc_get_root(state->doc);
-    yyjson_val *key;
-    yyjson_obj_iter obj_iter = yyjson_obj_iter_with(obj); // MUST be an object
-    
-    while ((key = yyjson_obj_iter_next(&obj_iter))) {
-      yyjson_val *val = yyjson_obj_iter_get_val(key);
-      
-      int name_idx = -1;
-      for (int i = 0; i < state->ncols; i++) {
-        if (yyjson_equals_str(key, state->colnames[i])) {
-          name_idx = i;
-          break;
-        }
+    uint8_t root_type = yyjson_get_type(obj);
+
+    // Auto-detect mode from first parsed line
+    if (array_mode == -1) {
+      if (root_type == YYJSON_TYPE_OBJ) {
+        array_mode = 0;
+      } else if (root_type == YYJSON_TYPE_ARR) {
+        array_mode = 1;
+      } else {
+        error_and_destroy_state(state, "parse_ndjson_as_df() requires JSON objects or arrays on each line");
       }
-      if (name_idx < 0) {
-        // Name has not been seen yet
-        name_idx = state->ncols;
-        char *new_name = (char *)yyjson_get_str(key);
-        size_t n = strlen(new_name) + 1;
-        state->colnames[state->ncols] = calloc(n, 1);
-        if (state->colnames[state->ncols] == 0) {
-          error_and_destroy_state(state, "Failed to allocate 'colname'");
-        }
-        strcpy(state->colnames[state->ncols], new_name);
-        state->ncols++;
-        if (state->ncols == MAX_DF_COLS) {
-          // TODO: Switch to dynamic allocation and 'realloc()' as needed.
-          // Free the 'colnames' we copied out of JSON docs when probing
+    }
+
+    if (array_mode == 1) {
+      // Array mode: track types by position
+      size_t arr_size = yyjson_arr_size(obj);
+      if ((int)arr_size > state->ncols) {
+        state->ncols = (int)arr_size;
+        if (state->ncols >= MAX_DF_COLS) {
           error_and_destroy_state(state, "Maximum columns for data.frame exceeded: %i", MAX_DF_COLS);
         }
       }
-      
-      type_bitset[name_idx] = update_type_bitset(type_bitset[name_idx], val, &opt);
+      yyjson_arr_iter arr_iter = yyjson_arr_iter_with(obj);
+      yyjson_val *val;
+      int apos = 0;
+      while ((val = yyjson_arr_iter_next(&arr_iter))) {
+        type_bitset[apos] = update_type_bitset(type_bitset[apos], val, &opt);
+        apos++;
+      }
+    } else {
+      // Object mode: existing key-based probing
+      yyjson_val *key;
+      yyjson_obj_iter obj_iter = yyjson_obj_iter_with(obj);
+
+      while ((key = yyjson_obj_iter_next(&obj_iter))) {
+        yyjson_val *val = yyjson_obj_iter_get_val(key);
+
+        int name_idx = -1;
+        for (int j = 0; j < state->ncols; j++) {
+          if (yyjson_equals_str(key, state->colnames[j])) {
+            name_idx = j;
+            break;
+          }
+        }
+        if (name_idx < 0) {
+          // Name has not been seen yet
+          name_idx = state->ncols;
+          char *new_name = (char *)yyjson_get_str(key);
+          size_t n = strlen(new_name) + 1;
+          state->colnames[state->ncols] = calloc(n, 1);
+          if (state->colnames[state->ncols] == 0) {
+            error_and_destroy_state(state, "Failed to allocate 'colname'");
+          }
+          strcpy(state->colnames[state->ncols], new_name);
+          state->ncols++;
+          if (state->ncols == MAX_DF_COLS) {
+            error_and_destroy_state(state, "Maximum columns for data.frame exceeded: %i", MAX_DF_COLS);
+          }
+        }
+
+        type_bitset[name_idx] = update_type_bitset(type_bitset[name_idx], val, &opt);
+      }
     }
-    
+
     yyjson_doc_free(state->doc);
     state->doc = NULL;
-    
+
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // Advance string 
+    // Advance string
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     total_read += pos + 1;
     str += pos + 1;
     str_size -= (pos + 1);
-    
-    
-    nrows++;    
-    nprobe--; 
+
+
+    nrows++;
+    nprobe--;
   }
-  // Rprintf("Step X0: nrows = %i\n", nrows);
-  
-  // json <- write_ndjson_str(head(mtcars)); read_ndjson_str(json)
-  
+
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // Read the rest of the string to figure out how many rows there are in total
-  // TODO: Just count "\n" here
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   if (total_read < orig_str_size) {
     for (size_t sp = 0; sp < str_size; sp++) {
@@ -857,8 +1002,8 @@ SEXP parse_ndjson_str_as_df_(SEXP str_, SEXP nread_, SEXP nskip_, SEXP nprobe_, 
         nrows++;
       }
     }
-    if (str[str_size =1] != '\n') {
-      // STring does not end in newline, so need to manually count the last row
+    if (str_size > 0 && str[str_size - 1] != '\n') {
+      // String does not end in newline, so need to manually count the last row
       nrows++;
     }
   }
@@ -868,15 +1013,46 @@ SEXP parse_ndjson_str_as_df_(SEXP str_, SEXP nread_, SEXP nskip_, SEXP nprobe_, 
   // and how many they want to skip.
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   nrows = nrows > nread ? nread : nrows;
-  
-  
+
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // Set column names for array mode
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  if (array_mode == 1) {
+    if (!Rf_isNull(col_names_) && TYPEOF(col_names_) == STRSXP) {
+      int user_ncols = Rf_length(col_names_);
+      if (user_ncols != state->ncols) {
+        error_and_destroy_state(state, "col_names length (%d) does not match array size (%d)", user_ncols, state->ncols);
+      }
+      for (int i = 0; i < state->ncols; i++) {
+        const char *nm = CHAR(STRING_ELT(col_names_, i));
+        size_t n = strlen(nm) + 1;
+        state->colnames[i] = calloc(n, 1);
+        if (state->colnames[i] == NULL) {
+          error_and_destroy_state(state, "Failed to allocate colname");
+        }
+        strcpy(state->colnames[i], nm);
+      }
+    } else {
+      for (int i = 0; i < state->ncols; i++) {
+        char nbuf[32];
+        snprintf(nbuf, sizeof(nbuf), "V%d", i + 1);
+        size_t n = strlen(nbuf) + 1;
+        state->colnames[i] = calloc(n, 1);
+        if (state->colnames[i] == NULL) {
+          error_and_destroy_state(state, "Failed to allocate colname");
+        }
+        strcpy(state->colnames[i], nbuf);
+      }
+    }
+  }
+
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // Create a list to hold vectors
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   SEXP df_ = PROTECT(Rf_allocVector(VECSXP, state->ncols)); nprotect++;
-  
-  
-  
+
+
+
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // For each column name,
   //   - determine the best SEXP to represent the 'type_bitset'
@@ -888,34 +1064,34 @@ SEXP parse_ndjson_str_as_df_(SEXP str_, SEXP nread_, SEXP nskip_, SEXP nprobe_, 
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   for (unsigned int col = 0; col < state->ncols; col++) {
     sexp_type[col] = get_best_sexp_to_represent_type_bitset(type_bitset[col], &opt);
-    
+
     // INT64SXP is actually contained in a REALSXP
     unsigned int alloc_type = sexp_type[col] == INT64SXP ? REALSXP : sexp_type[col];
-    
+
     // Allocate memory for column
     SEXP vec_ = PROTECT(Rf_allocVector(alloc_type, nrows));
     if (sexp_type[col] == INT64SXP) {
       Rf_setAttrib(vec_, R_ClassSymbol, Rf_mkString("integer64"));
     }
-    
+
     // place vector into list
     SET_VECTOR_ELT(df_, col, vec_);
     UNPROTECT(1); // no longer needs protection once part of data.frame
   }
-  
-  
+
+
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  // Parse file
+  // Parse data
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   str        = mark_str;
   str_size   = mark_str_size;
   total_read = mark_total_read;
-  
+
   // keep track of actual number of rows parsed.
-  // This might not be the same as 'nrow' as we can skip rows that we 
+  // This might not be the same as 'nrow' as we can skip rows that we
   // can't parse.
   int row = 0;
-  
+
   for (unsigned int i = 0; i < nrows; i++) {
     yyjson_read_err err;
     state->doc = yyjson_read_opts(str, str_size, opt.yyjson_read_flag, NULL, &err);
@@ -923,72 +1099,125 @@ SEXP parse_ndjson_str_as_df_(SEXP str_, SEXP nread_, SEXP nskip_, SEXP nprobe_, 
     if (state->doc == NULL) {
       error_and_destroy_state(state, "Couldn't parse JSON on line %i\n", i + 1);
     }
-    
+
     yyjson_val *obj = yyjson_doc_get_root(state->doc);
-    if (yyjson_get_type(obj) != YYJSON_TYPE_OBJ) {
-      error_and_destroy_state(state, "parse_ndjson_as_df() only works if all lines represent JSON objects");
-    }
-    
-    for (unsigned int col = 0; col < state->ncols; col++) {
-      SEXP column_ = VECTOR_ELT(df_, col);
-      
-      yyjson_val *val = yyjson_obj_get(obj, state->colnames[col]);
-      
-      switch(sexp_type[col]) {
-      case LGLSXP:
-        LOGICAL(column_)[row] = json_val_to_logical(val, &opt);
-        break;
-      case INTSXP:
-        INTEGER(column_)[row] = json_val_to_integer(val, &opt);
-        break;
-      case INT64SXP: {
-        long long tmp = json_val_to_integer64(val, &opt);
-        ((long long *)(REAL(column_)))[row] = tmp;
+
+    if (array_mode == 1) {
+      // Array mode: extract values by position
+      if (yyjson_get_type(obj) != YYJSON_TYPE_ARR) {
+        error_and_destroy_state(state, "Expected JSON array on line %i", i + 1);
       }
-        break;
-      case REALSXP:
-        REAL(column_)[row] = json_val_to_double(val, &opt);
-        break;
-      case STRSXP:
-        if (val == NULL) {
-          SET_STRING_ELT(column_, row, NA_STRING);
-        } else {
+      yyjson_arr_iter arr_iter = yyjson_arr_iter_with(obj);
+      yyjson_val *val;
+      unsigned int col = 0;
+      while ((val = yyjson_arr_iter_next(&arr_iter)) && col < state->ncols) {
+        SEXP column_ = VECTOR_ELT(df_, col);
+        switch(sexp_type[col]) {
+        case LGLSXP:
+          LOGICAL(column_)[row] = json_val_to_logical(val, &opt);
+          break;
+        case INTSXP:
+          INTEGER(column_)[row] = json_val_to_integer(val, &opt);
+          break;
+        case INT64SXP: {
+          long long tmp = json_val_to_integer64(val, &opt);
+          ((long long *)(REAL(column_)))[row] = tmp;
+        }
+          break;
+        case REALSXP:
+          REAL(column_)[row] = json_val_to_double(val, &opt);
+          break;
+        case STRSXP:
           SET_STRING_ELT(column_, row, json_val_to_charsxp(val, &opt));
-        }
-        break;
-      case VECSXP:
-        if (val == NULL) {
-          SET_VECTOR_ELT(column_, row, opt.df_missing_list_elem);
-        } else {
+          break;
+        case VECSXP:
           SET_VECTOR_ELT(column_, row, json_as_robj(val, &opt, state));
+          break;
+        default:
+          error_and_destroy_state(state, "parse_ndjson_str_as_df_(): Unknown type");
         }
-        break;
-      default:
-        error_and_destroy_state(state, "parse_ndjson_file_as_df_(): Unknown type");
-      } 
-      
+        col++;
+      }
+      // Fill remaining columns with NA if this row had fewer elements
+      for (; col < state->ncols; col++) {
+        SEXP column_ = VECTOR_ELT(df_, col);
+        switch(sexp_type[col]) {
+        case LGLSXP:  LOGICAL(column_)[row] = NA_LOGICAL; break;
+        case INTSXP:  INTEGER(column_)[row] = NA_INTEGER; break;
+        case INT64SXP: ((long long *)(REAL(column_)))[row] = INT64_MIN; break;
+        case REALSXP: REAL(column_)[row] = NA_REAL; break;
+        case STRSXP:  SET_STRING_ELT(column_, row, NA_STRING); break;
+        case VECSXP:  SET_VECTOR_ELT(column_, row, opt.df_missing_list_elem); break;
+        default: break;
+        }
+      }
+    } else {
+      // Object mode: extract values by key name
+      if (yyjson_get_type(obj) != YYJSON_TYPE_OBJ) {
+        error_and_destroy_state(state, "parse_ndjson_as_df() only works if all lines represent JSON objects");
+      }
+
+      for (unsigned int col = 0; col < state->ncols; col++) {
+        SEXP column_ = VECTOR_ELT(df_, col);
+
+        yyjson_val *val = yyjson_obj_get(obj, state->colnames[col]);
+
+        switch(sexp_type[col]) {
+        case LGLSXP:
+          LOGICAL(column_)[row] = json_val_to_logical(val, &opt);
+          break;
+        case INTSXP:
+          INTEGER(column_)[row] = json_val_to_integer(val, &opt);
+          break;
+        case INT64SXP: {
+          long long tmp = json_val_to_integer64(val, &opt);
+          ((long long *)(REAL(column_)))[row] = tmp;
+        }
+          break;
+        case REALSXP:
+          REAL(column_)[row] = json_val_to_double(val, &opt);
+          break;
+        case STRSXP:
+          if (val == NULL) {
+            SET_STRING_ELT(column_, row, NA_STRING);
+          } else {
+            SET_STRING_ELT(column_, row, json_val_to_charsxp(val, &opt));
+          }
+          break;
+        case VECSXP:
+          if (val == NULL) {
+            SET_VECTOR_ELT(column_, row, opt.df_missing_list_elem);
+          } else {
+            SET_VECTOR_ELT(column_, row, json_as_robj(val, &opt, state));
+          }
+          break;
+        default:
+          error_and_destroy_state(state, "parse_ndjson_str_as_df_(): Unknown type");
+        }
+
+      }
     }
-    
+
     yyjson_doc_free(state->doc);
     state->doc = NULL;
-    
+
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // Advance string 
+    // Advance string
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     total_read += pos + 1;
     str += pos + 1;
     str_size -= (pos + 1);
-    
-    
+
+
     row++;
   }
-  
+
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // Promote the 'list' of accumulated vectors to be a real 'data.frame'
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   truncate_list_of_vectors(df_, row, nrows);
   df_ = PROTECT(promote_list_to_data_frame(df_, state->colnames, state->ncols));  nprotect++;
-  
+
   destroy_state(state);
   UNPROTECT(nprotect);
   return df_;

--- a/src/ndjson-serialize.c
+++ b/src/ndjson-serialize.c
@@ -149,87 +149,106 @@ SEXP serialize_df_to_ndjson_file_(SEXP robj_, SEXP filename_, SEXP serialize_opt
   R_xlen_t ncols = Rf_xlength(robj_);
   R_xlen_t nrows = Rf_xlength(VECTOR_ELT(robj_, 0));
   SEXP nms_ = PROTECT(Rf_getAttrib(robj_, R_NamesSymbol));
-  
+  int has_names = !Rf_isNull(nms_);
+
+  // For unnamed data frames, pre-compute column types for array output
+  unsigned int *col_type = NULL;
+  if (!has_names) {
+    col_type = detect_data_frame_types(robj_, &opt);
+  }
+
   FILE *file = NULL;
   const char *filename = CHAR(STRING_ELT(filename_, 0));
   file = fopen(filename, "w");
   if (file == NULL) {
+    if (col_type != NULL) free(col_type);
     Rf_error("Couldn't open file: %s", filename);
   }
-  
+
   for (unsigned int row = 0; row < nrows; row++) {
     yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
-    yyjson_mut_val *obj = yyjson_mut_obj(doc);
-    for (unsigned int col = 0; col < ncols; col++) {
-      const char *key_str = CHAR(STRING_ELT(nms_, col));
-      yyjson_mut_val *key = yyjson_mut_str(doc, key_str);
-      yyjson_mut_val *val;
-      SEXP col_ = VECTOR_ELT(robj_, col);
-      
-      switch(TYPEOF(col_)) {
-      case LGLSXP:
-        val = scalar_logical_to_json_val(INTEGER(col_)[row], doc, &opt);
-        break;
-      case INTSXP:
-        if (Rf_isFactor(col_)) {
-          val = scalar_factor_to_json_val(col_, row, doc, &opt);
-        } else if (Rf_inherits(col_, "Date")) {
+    yyjson_mut_val *root;
+
+    if (has_names) {
+      // Named data frame: serialize each row as a JSON object with keys
+      yyjson_mut_val *obj = yyjson_mut_obj(doc);
+      for (unsigned int col = 0; col < ncols; col++) {
+        const char *key_str = CHAR(STRING_ELT(nms_, col));
+        yyjson_mut_val *key = yyjson_mut_str(doc, key_str);
+        yyjson_mut_val *val;
+        SEXP col_ = VECTOR_ELT(robj_, col);
+
+        switch(TYPEOF(col_)) {
+        case LGLSXP:
+          val = scalar_logical_to_json_val(INTEGER(col_)[row], doc, &opt);
+          break;
+        case INTSXP:
+          if (Rf_isFactor(col_)) {
+            val = scalar_factor_to_json_val(col_, row, doc, &opt);
+          } else if (Rf_inherits(col_, "Date")) {
+            val = scalar_date_to_json_val(col_, row, doc, &opt);
+          } else if (Rf_inherits(col_, "POSIXct")) {
+            val = scalar_posixct_to_json_val(col_, row, doc, &opt);
+          } else {
+            val = scalar_integer_to_json_val(INTEGER(col_)[row], doc, &opt);
+          }
+          break;
+        case REALSXP: {
+          if (Rf_inherits(col_, "Date")) {
           val = scalar_date_to_json_val(col_, row, doc, &opt);
         } else if (Rf_inherits(col_, "POSIXct")) {
           val = scalar_posixct_to_json_val(col_, row, doc, &opt);
+        } else if (Rf_inherits(col_, "integer64")) {
+          val = scalar_integer64_to_json_val(col_, row, doc, &opt);
         } else {
-          val = scalar_integer_to_json_val(INTEGER(col_)[row], doc, &opt);
+          val = scalar_double_to_json_val(REAL(col_)[row], doc, &opt);
         }
-        break;
-      case REALSXP: {
-        if (Rf_inherits(col_, "Date")) {
-        val = scalar_date_to_json_val(col_, row, doc, &opt);
-      } else if (Rf_inherits(col_, "POSIXct")) {
-        val = scalar_posixct_to_json_val(col_, row, doc, &opt);
-      } else if (Rf_inherits(col_, "integer64")) {
-        val = scalar_integer64_to_json_val(col_, row, doc, &opt);
-      } else {
-        val = scalar_double_to_json_val(REAL(col_)[row], doc, &opt);
+        }
+          break;
+        case STRSXP: {
+          val = scalar_strsxp_to_json_val(col_, row, doc, &opt);
+        }
+          break;
+        case VECSXP:
+          val = serialize_core(VECTOR_ELT(col_, row), doc, &opt);
+          break;
+        case RAWSXP:
+          val = scalar_rawsxp_to_json_val(col_, row, doc, &opt);
+          break;
+        default:
+          Rf_error("data_frame_to_json_array_of_objects(): Unhandled scalar SEXP: %s\n", Rf_type2char((SEXPTYPE)TYPEOF(col_)));
+        }
+        // Add value to row obj
+        if (val != NULL) {
+          yyjson_mut_obj_add(obj, key, val);
+        }
       }
-      }
-        break;
-      case STRSXP: {
-        val = scalar_strsxp_to_json_val(col_, row, doc, &opt);
-      }
-        break;
-      case VECSXP:
-        val = serialize_core(VECTOR_ELT(col_, row), doc, &opt);
-        break;
-      case RAWSXP:
-        val = scalar_rawsxp_to_json_val(col_, row, doc, &opt);
-        break;
-      default:
-        Rf_error("data_frame_to_json_array_of_objects(): Unhandled scalar SEXP: %s\n", Rf_type2char((SEXPTYPE)TYPEOF(col_)));
-      }
-      // Add value to row obj
-      if (val != NULL) {
-        yyjson_mut_obj_add(obj, key, val);
-      }
+      root = obj;
+    } else {
+      // Unnamed data frame: serialize each row as a JSON array
+      root = data_frame_row_to_json_array(robj_, col_type, row, -1, doc, &opt);
     }
-    yyjson_mut_doc_set_root(doc, obj);
-    
+
+    yyjson_mut_doc_set_root(doc, root);
+
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Write to JSON string
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     yyjson_write_err err;
-    bool res = yyjson_mut_write_fp(file, doc, opt.yyjson_write_flag, NULL, &err);  
+    bool res = yyjson_mut_write_fp(file, doc, opt.yyjson_write_flag, NULL, &err);
     if (!res) {
       Rf_error("Error writing to file at row %i\n", row);
     }
     fputc('\n', file);
-    
+
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // tidy and return
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     yyjson_mut_doc_free(doc);
-    
+
   }
-  
+
+  if (col_type != NULL) free(col_type);
   fclose(file);
   UNPROTECT(1);
   return R_NilValue;
@@ -262,65 +281,82 @@ SEXP serialize_df_to_ndjson_str_(SEXP robj_, SEXP serialize_opts_, SEXP as_raw_)
   R_xlen_t ncols = Rf_xlength(robj_);
   R_xlen_t nrows = Rf_xlength(VECTOR_ELT(robj_, 0));
   SEXP nms_ = PROTECT(Rf_getAttrib(robj_, R_NamesSymbol));
-  
+  int has_names = !Rf_isNull(nms_);
+
+  // For unnamed data frames, pre-compute column types for array output
+  unsigned int *col_type = NULL;
+  if (!has_names) {
+    col_type = detect_data_frame_types(robj_, &opt);
+  }
+
   char **ndjson = NULL;
-  ndjson = (char **)calloc((unsigned long)nrows, sizeof(char *));      
-  
+  ndjson = (char **)calloc((unsigned long)nrows, sizeof(char *));
+
   for (R_xlen_t row = 0; row < nrows; row++) {
     yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
-    yyjson_mut_val *obj = yyjson_mut_obj(doc);
-    for (R_xlen_t col = 0; col < ncols; col++) {
-      const char *key_str = CHAR(STRING_ELT(nms_, col));
-      yyjson_mut_val *key = yyjson_mut_str(doc, key_str);
-      yyjson_mut_val *val;
-      SEXP col_ = VECTOR_ELT(robj_, col);
-      
-      switch(TYPEOF(col_)) {
-      case LGLSXP:
-        val = scalar_logical_to_json_val(INTEGER(col_)[row], doc, &opt);
-        break;
-      case INTSXP:
-        if (Rf_isFactor(col_)) {
-          val = scalar_factor_to_json_val(col_, row, doc, &opt);
-        } else if (Rf_inherits(col_, "Date")) {
+    yyjson_mut_val *root;
+
+    if (has_names) {
+      // Named data frame: serialize each row as a JSON object with keys
+      yyjson_mut_val *obj = yyjson_mut_obj(doc);
+      for (R_xlen_t col = 0; col < ncols; col++) {
+        const char *key_str = CHAR(STRING_ELT(nms_, col));
+        yyjson_mut_val *key = yyjson_mut_str(doc, key_str);
+        yyjson_mut_val *val;
+        SEXP col_ = VECTOR_ELT(robj_, col);
+
+        switch(TYPEOF(col_)) {
+        case LGLSXP:
+          val = scalar_logical_to_json_val(INTEGER(col_)[row], doc, &opt);
+          break;
+        case INTSXP:
+          if (Rf_isFactor(col_)) {
+            val = scalar_factor_to_json_val(col_, row, doc, &opt);
+          } else if (Rf_inherits(col_, "Date")) {
+            val = scalar_date_to_json_val(col_, row, doc, &opt);
+          } else if (Rf_inherits(col_, "POSIXct")) {
+            val = scalar_posixct_to_json_val(col_, row, doc, &opt);
+          } else {
+            val = scalar_integer_to_json_val(INTEGER(col_)[row], doc, &opt);
+          }
+          break;
+        case REALSXP: {
+          if (Rf_inherits(col_, "Date")) {
           val = scalar_date_to_json_val(col_, row, doc, &opt);
         } else if (Rf_inherits(col_, "POSIXct")) {
           val = scalar_posixct_to_json_val(col_, row, doc, &opt);
+        } else if (Rf_inherits(col_, "integer64")) {
+          val = scalar_integer64_to_json_val(col_, row, doc, &opt);
         } else {
-          val = scalar_integer_to_json_val(INTEGER(col_)[row], doc, &opt);
+          val = scalar_double_to_json_val(REAL(col_)[row], doc, &opt);
         }
-        break;
-      case REALSXP: {
-        if (Rf_inherits(col_, "Date")) {
-        val = scalar_date_to_json_val(col_, row, doc, &opt);
-      } else if (Rf_inherits(col_, "POSIXct")) {
-        val = scalar_posixct_to_json_val(col_, row, doc, &opt);
-      } else if (Rf_inherits(col_, "integer64")) {
-        val = scalar_integer64_to_json_val(col_, row, doc, &opt);
-      } else {
-        val = scalar_double_to_json_val(REAL(col_)[row], doc, &opt);
+        }
+          break;
+        case STRSXP: {
+          val = scalar_strsxp_to_json_val(col_, row, doc, &opt);
+        }
+          break;
+        case VECSXP:
+          val = serialize_core(VECTOR_ELT(col_, row), doc, &opt);
+          break;
+        case RAWSXP:
+          val = scalar_rawsxp_to_json_val(col_, row, doc, &opt);
+          break;
+        default:
+          Rf_error("data_frame_to_json_array_of_objects(): Unhandled scalar SEXP: %s\n", Rf_type2char((SEXPTYPE)TYPEOF(col_)));
+        }
+        // Add value to row obj
+        if (val != NULL) {
+          yyjson_mut_obj_add(obj, key, val);
+        }
       }
-      }
-        break;
-      case STRSXP: {
-        val = scalar_strsxp_to_json_val(col_, row, doc, &opt);
-      }
-        break;
-      case VECSXP:
-        val = serialize_core(VECTOR_ELT(col_, row), doc, &opt);
-        break;
-      case RAWSXP:
-        val = scalar_rawsxp_to_json_val(col_, row, doc, &opt);
-        break;
-      default:
-        Rf_error("data_frame_to_json_array_of_objects(): Unhandled scalar SEXP: %s\n", Rf_type2char((SEXPTYPE)TYPEOF(col_)));
-      }
-      // Add value to row obj
-      if (val != NULL) {
-        yyjson_mut_obj_add(obj, key, val);
-      }
+      root = obj;
+    } else {
+      // Unnamed data frame: serialize each row as a JSON array
+      root = data_frame_row_to_json_array(robj_, col_type, row, -1, doc, &opt);
     }
-    yyjson_mut_doc_set_root(doc, obj);
+
+    yyjson_mut_doc_set_root(doc, root);
     
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Write to JSON string
@@ -333,7 +369,9 @@ SEXP serialize_df_to_ndjson_str_(SEXP robj_, SEXP serialize_opts_, SEXP as_raw_)
     yyjson_mut_doc_free(doc);
     
   }
-  
+
+  if (col_type != NULL) free(col_type);
+
   // concatenate into single string for return to R
   unsigned int total_len = 1; // extra '1' for '\0' byte at end of string
   for (unsigned int row = 0; row < nrows; row++) {

--- a/tests/testthat/test-ndjson.R
+++ b/tests/testthat/test-ndjson.R
@@ -148,6 +148,109 @@ test_that("read_ndjson_str() empty inputs", {
 
 
 
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Write unnamed data frame rows as JSON arrays
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+test_that("write_ndjson_str with unnamed df produces arrays", {
+  df <- data.frame(a = 1:3, b = c("x", "y", "z"), stringsAsFactors = FALSE)
+
+  # Named: should produce objects
+  json_named <- write_ndjson_str(df)
+  expect_true(grepl("^\\{", strsplit(json_named, "\n")[[1]][1]))
+
+  # Unnamed: should produce arrays
+  json_unnamed <- write_ndjson_str(unname(df))
+  lines <- strsplit(json_unnamed, "\n")[[1]]
+  expect_true(grepl("^\\[", lines[1]))
+  expect_equal(lines[1], '[1,"x"]')
+  expect_equal(lines[2], '[2,"y"]')
+  expect_equal(lines[3], '[3,"z"]')
+})
+
+test_that("write_ndjson_file with unnamed df produces arrays", {
+  df <- data.frame(a = 1.5, b = TRUE, stringsAsFactors = FALSE)
+  tmp <- tempfile()
+  write_ndjson_file(unname(df), tmp)
+  lines <- readLines(tmp)
+  expect_equal(lines[1], '[1.5,true]')
+})
+
+test_that("write_ndjson_str and write_ndjson_file agree for unnamed df", {
+  df <- unname(data.frame(a = 1:2, b = c("x", "y"), stringsAsFactors = FALSE))
+  tmp <- tempfile()
+  write_ndjson_file(df, tmp)
+  from_file <- paste(readLines(tmp), collapse = "\n")
+  from_str <- write_ndjson_str(df)
+  expect_identical(from_file, from_str)
+})
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Read array-format NDJSON lines as data frame
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+test_that("read_ndjson_str handles array-format lines as df", {
+  input <- '[1,"a",true]\n[2,"b",false]\n[3,"c",true]'
+  result <- read_ndjson_str(input, type = 'df')
+  expect_equal(ncol(result), 3)
+  expect_equal(nrow(result), 3)
+  expect_equal(names(result), c("V1", "V2", "V3"))
+  expect_equal(result$V1, c(1L, 2L, 3L))
+  expect_equal(result$V2, c("a", "b", "c"))
+  expect_equal(result$V3, c(TRUE, FALSE, TRUE))
+})
+
+test_that("read_ndjson_str handles array-format with col_names", {
+  input <- '[1,"a"]\n[2,"b"]'
+  result <- read_ndjson_str(input, type = 'df', col_names = c("id", "val"))
+  expect_equal(names(result), c("id", "val"))
+  expect_equal(result$id, c(1L, 2L))
+  expect_equal(result$val, c("a", "b"))
+})
+
+test_that("read_ndjson_file handles array-format lines", {
+  df <- data.frame(a = 1:3, b = c("x", "y", "z"), stringsAsFactors = FALSE)
+  tmp <- tempfile()
+  write_ndjson_file(unname(df), tmp)
+  result <- read_ndjson_file(tmp, col_names = c("a", "b"))
+  expect_equal(result$a, 1:3)
+  expect_equal(result$b, c("x", "y", "z"))
+})
+
+test_that("read_ndjson_str with nskip and array-format", {
+  input <- '{"meta":"header"}\n[1,2]\n[3,4]'
+  result <- read_ndjson_str(input, type = 'df', nskip = 1, col_names = c("x", "y"))
+  expect_equal(nrow(result), 2)
+  expect_equal(result$x, c(1L, 3L))
+  expect_equal(result$y, c(2L, 4L))
+})
+
+test_that("col_names length mismatch errors", {
+  input <- '[1,2,3]\n[4,5,6]'
+  expect_error(
+    read_ndjson_str(input, type = 'df', col_names = c("a", "b")),
+    "col_names length"
+  )
+})
+
+test_that("roundtrip: write unnamed df as arrays, read back", {
+  df <- data.frame(
+    x = c(1.1, 2.2, 3.3),
+    y = c("a", "b", "c"),
+    z = c(TRUE, FALSE, TRUE),
+    stringsAsFactors = FALSE
+  )
+
+  # Write as arrays
+  json <- write_ndjson_str(unname(df))
+
+  # Read back with original column names
+  result <- read_ndjson_str(json, col_names = names(df))
+
+  expect_equal(result$x, df$x)
+  expect_equal(result$y, df$y)
+  expect_equal(result$z, df$z)
+})
+
+
 test_that("read_ndjson_raw() empty inputs", {
   
   input <- write_ndjson_raw(head(mtcars, 2))

--- a/tests/testthat/test-unboxing-AsIs-handling.R
+++ b/tests/testthat/test-unboxing-AsIs-handling.R
@@ -43,5 +43,55 @@ test_that("AsIs handling works", {
   
   s2 <- write_json_str(x, auto_unbox = TRUE)
   expect_identical(s, s2)
-    
+
+})
+
+
+test_that("asis = 'strip' ignores AsIs with auto_unbox", {
+  l <- list(a = 1, b = I(2))
+
+  # Default: keep (existing behavior)
+  expect_equal(
+    write_json_str(l, auto_unbox = TRUE),
+    '{"a":1.0,"b":[2.0]}'
+  )
+
+  # Strip: ignore AsIs, unbox normally
+  expect_equal(
+    write_json_str(l, auto_unbox = TRUE, asis = "strip"),
+    '{"a":1.0,"b":2.0}'
+  )
+
+  # Without auto_unbox, asis has no effect
+  expect_equal(
+    write_json_str(l, auto_unbox = FALSE, asis = "strip"),
+    '{"a":[1.0],"b":[2.0]}'
+  )
+})
+
+
+test_that("asis = 'keep' is default and backward compatible", {
+  l <- list(a = I(1))
+  expect_equal(
+    write_json_str(l, auto_unbox = TRUE, asis = "keep"),
+    '{"a":[1.0]}'
+  )
+  # Same as default
+  expect_equal(
+    write_json_str(l, auto_unbox = TRUE),
+    '{"a":[1.0]}'
+  )
+})
+
+
+test_that("asis = 'strip' works with string AsIs from format()", {
+  l <- list(val = I("hello"))
+  expect_equal(
+    write_json_str(l, auto_unbox = TRUE, asis = "strip"),
+    '{"val":"hello"}'
+  )
+  expect_equal(
+    write_json_str(l, auto_unbox = TRUE),
+    '{"val":["hello"]}'
+  )
 })


### PR DESCRIPTION
## NDJSON Array Format Support for CDISC Dataset JSON

In my R packagee datasetjson, we use yyjsonr under the hood. It's massively improved performance of the package and was pretty much a drop in replacement for jsonlite, so - thank you!

The datasetjson package handles writing out datasets following a industry standard called Dataset JSON, and the Dataset JSON specification also has details for writing NDJSON files. The current implementation of `write_ndjson_str()` forces dataframes to write out with names attached to the array, but the Dataset NDJSON standard stores that metadata in the first row and removes it from subsequent rows. Here's an example:

```json


{"datasetJSONCreationDateTime": "2023-06-28T15:38:43", "datasetJSONVersion": "1.1.0", "fileOID": "www.sponsor.xyz.org.project123.final", "dbLastModifiedDateTime": "2023-05-31T00:00:00", "originator": "Sponsor XYZ", "sourceSystem": {"name": "Software ABC", "version": "1.0.0"}, "studyOID": "cdisc.com.CDISCPILOT01", "metaDataVersionOID": "MDV.MSGv2.0.SDTMIG.3.3.SDTM.1.7", "metaDataRef": "https://metadata.location.org/CDISCPILOT01/define.xml", "itemGroupOID": "IG.DM", "records": 18, "name": "DM", "label": "Demographics", "columns": [{"itemOID": "IT.DM.STUDYID", "name": "STUDYID", "label": "Study Identifier", "dataType": "string", "length": 12, "keySequence": 1}, {"itemOID": "IT.DM.DOMAIN", "name": "DOMAIN", "label": "Domain Abbreviation", "dataType": "string", "length": 2},  {"itemOID": "IT.DM.USUBJID", "name": "USUBJID", "label": "Unique Subject Identifier", "dataType": "string", "length": 8, "keySequence": 2}, ..., {"itemOID": "IT.DM.AGE", "name": "AGE", "label": "Age", "dataType": "integer"}, {"itemOID": "IT.DM.AGEU", "name": "AGEU", "label": "Age Units", "dataType": "string", "length": 5}, ...]}
["CDISCPILOT01", "DM", "CDISC001", ..., 84, "YEARS", ...]
["CDISCPILOT01", "DM", "CDISC002", ..., 76, "YEARS", ...]
["CDISCPILOT01", "DM", "CDISC003", ..., 61, "YEARS", ...]
 ...
```

Right now, to write the NDJSON files I have to do a workaround which negates the speed of yyjsonr, because I have to fallback on R for the row by row conversion to JSON. You can see my section of code right [here](https://github.com/atorus-research/datasetjson/blob/23c5ec253497fd0c557e966ecd796669e115fca4/R/write_dataset_ndjson.R#L72)

In this PR, I've introduced added updates to support the reading and writing based on my use case. Existing functionality remains untouched and all unit tests pass. 

**Please note that I did this update using Claude Code.**

### Summary

- Write data frame rows as JSON arrays via `write_ndjson_*(unname(df))`
- Read array-format NDJSON lines into data frames with new `col_names` parameter
- New `asis = c("keep", "strip")` option in `opts_write_json()` to bypass `AsIs` class with `auto_unbox`
- Fix pre-existing bug in NDJSON string parser (`=` instead of `-`)

### Usage

```r
# Write rows as arrays
write_ndjson_str(unname(df))
#> ["S1",52,75.3]

# Read array-format NDJSON, with nskip to skip a header line
read_ndjson_file("data.ndjson", nskip = 1, col_names = c("STUDYID", "AGE", "WEIGHT"))

# Strip AsIs class to allow auto_unbox on I() values
write_json_str(list(a = I(1)), auto_unbox = TRUE, asis = "strip")
#> {"a":1.0}
```

### Test plan

- [x] New tests for array write/read, `asis` option, and roundtrip
- [x] All existing tests pass
- [x] `R CMD check` passes (no code-related warnings or errors)
